### PR TITLE
feat: init-script to initiate environment for profile

### DIFF
--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -14,9 +14,10 @@ type Profiles map[string]*Profile
 type Profile struct {
 	// set it with mapstructure remain to unmashal config file item `profiles` as Profile
 	// yaml inline fixed the nested profiles issue
-	Profiles Profiles `mapstructure:",remain" yaml:",inline"`
-	Desc     string   `mapstructure:"desc" yaml:"desc,omitempty"`
-	Env      Envs     `mapstructure:"env" yaml:"env,omitempty"`
+	Profiles   Profiles `mapstructure:",remain" yaml:",inline"`
+	Desc       string   `mapstructure:"desc" yaml:"desc,omitempty"`
+	Env        Envs     `mapstructure:"env" yaml:"env,omitempty"`
+	InitScript string   `mapstructure:"init-script" yaml:"init-script,omitempty"`
 }
 
 // NewProfile creates the Profile


### PR DESCRIPTION
init-script to initiate environment for profile

### examples

- initiate environment for profile with login gcloud and configure docker login for gcr.io

```yaml
profiles:
  my-profile:
    init-script: |
      gcloud auth login
      gcloud auth configure-docker gcr.io
    env:
      - name: MY_VAR
        value: MY_VAL
```

- initiate environment for profile with login gcloud and configure and store kubeconfig in `$KUBECONFIG` which is `$HOME/.kube/my-kubeconfig`
```yaml
profiles:
  my-profile:
    init-script: |
      # login gcloud
      gcloud auth login
      # configure and store kubeconfig in $KUBECONFIG which is $HOME/.kube/my-kubeconfig
      gcloud container clusters get-credentials \
      my-cluster --region us-east4 --project my-project
    env:
      - name: KUBECONFIG
        value: $HOME/.kube/my-kubeconfig
```
