### PR TITLE
feat: Add support for multiple init-script

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.30.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -30,5 +30,4 @@ require (
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/sunggun-yu/envp/internal/util"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -59,7 +59,7 @@ func (c *ConfigFile) initConfigFile() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// return error if config file name is not seet
+	// return error if config file name is not set
 	if c.name == "" {
 		return fmt.Errorf("Config file is not set")
 	}
@@ -91,7 +91,7 @@ func (c *ConfigFile) Read() (*Config, error) {
 	if err := yaml.Unmarshal(b, &c.config); err != nil {
 		return nil, err
 	}
-	// set mutex to Config to syncronize object along with file operation
+	// set mutex to Config to synchronize object along with file operation
 	c.config.SetMutex(&c.mu)
 	return c.config, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/sunggun-yu/envp/internal/config"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -103,17 +103,18 @@ func (s *ShellCommand) execCommand(argv0 string, argv []string, profile *config.
 
 // executeInitScript executes the initial script for the shell
 func (s *ShellCommand) executeInitScript(profile *config.NamedProfile) error {
-
-	// just return if init-script is empty
-	if profile == nil || len(profile.InitScript) == 0 {
+	// Return if profile or init-script is empty
+	if profile == nil || profile.InitScript == nil {
 		return nil
 	}
 
-	cmd := s.createCommand(&profile.Env, "/bin/sh", "-c", profile.InitScript)
-
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("init-script error: %w", err)
+	// loop and run init script in order
+	for _, initScript := range profile.InitScripts() {
+		cmd := s.createCommand(&profile.Env, "/bin/sh", "-c", initScript)
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("init-script error: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -362,3 +362,34 @@ var _ = Describe("init-script", func() {
 		})
 	})
 })
+
+var _ = Describe("multiple init-script", func() {
+	var stdout, stderr bytes.Buffer
+	sc := NewShellCommand()
+	sc.Stdout = &stdout
+	sc.Stderr = &stderr
+
+	When("multiple init-script is defined", func() {
+		profile := config.NamedProfile{
+			Name:    "my-profile",
+			Profile: config.NewProfile(),
+		}
+
+		var initScripts []interface{}
+		initScripts = append(initScripts, map[string]interface{}{"run": "echo meow-1"})
+		initScripts = append(initScripts, map[string]interface{}{"run": "echo meow-2"})
+		initScripts = append(initScripts, map[string]interface{}{"something-else": "echo meow-2"})
+
+		profile.InitScript = initScripts
+
+		err := sc.executeInitScript(&profile)
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("output should only have result of run(s)", func() {
+			Expect(stdout.String()).To(Equal("meow-1\nmeow-2\n"))
+		})
+	})
+})

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -8,7 +8,7 @@ profiles:
       - name: HTTPS_PROXY
         value: http://192.168.1.10:443
       - name: NO_PROXY
-        value: localhost,127.0.0.1,.someapis.local
+        value: localhost,127.0.0.1,.some_apis.local
       - name: KUBECONFIG
         value: /Users/meow/.kube/lab-cluster1
     cluster2:
@@ -17,7 +17,7 @@ profiles:
       - name: HTTPS_PROXY
         value: http://192.168.1.20:443
       - name: NO_PROXY
-        value: localhost,127.0.0.1,.someapis.local
+        value: localhost,127.0.0.1,.some_apis.local
       - name: KUBECONFIG
         value: /Users/meow/.kube/lab-cluster2
     cluster3:
@@ -26,7 +26,7 @@ profiles:
       - name: HTTPS_PROXY
         value: http://192.168.1.30:443
       - name: NO_PROXY
-        value: localhost,127.0.0.1,.someapis.local
+        value: localhost,127.0.0.1,.some_apis.local
       - name: KUBECONFIG
         value: /Users/meow/.kube/lab-cluster3
   docker:
@@ -66,3 +66,34 @@ profiles:
           env:
           - name: HTTPS_PROXY
             value: http://192.168.2.11:3128
+  profile-with-init-script:
+    env:
+    - name: VAR
+      value: VAL
+    init-script: echo meow
+  profile-with-multi-init-script:
+    env:
+    - name: VAR
+      value: VAL
+    init-script:
+    - run: echo meow1
+    - run: echo meow2
+    - something-else: echo meow2
+  profile-with-multi-init-script-but-no-run:
+    env:
+    - name: VAR
+      value: VAL
+    init-script:
+    - something-else: echo meow1
+    - something-else: echo meow2
+    - something-else: echo meow2
+  profile-with-no-init-script:
+    env:
+    - name: VAR
+      value: VAL
+  profile-with-single-init-script-but-array:
+    env:
+    - name: VAR
+      value: VAL
+    init-script:
+    - run: echo meow


### PR DESCRIPTION
- implement an array type for `init-script` with the `run` keyword
- maintain backward compatibility for `init-script` as a single string
- upgrade Go YAML version from v2 to v3
- corrected typos in comments


Multiple `init-script` will be useful for reusable command with YAML Anchor 


example of multiple `init-script`

```yaml
commons:
  gcloud-login: &commons-gcloud-login |
    echo "login gcloud ..."
    gcloud auth login

profiles:
  my-profile-1:
    env:
      - name: VAR
        value: val
    init-script: |
      echo "meow"
      echo "woof"

  my-profile-2:
    env:
      - name: VAR
        value: val
    init-script: |
      - run: echo meow
      - run: |
          echo "woof"
          echo "meow"
      - file: "/some/path/this-will-be-ignored-only-run-keyword-is-supported"

  my-profile-3:
    env:
      - name: TEST1
        value: ~/.config
    init-script:
      - run: |
          echo "getting password from keepass ..."
          keepassxc-cli show -sa password /Users/myusuer/Documents/KeePass/default.kdbx test
      - run: *commons-gcloud-login
      - run: |
          echo "configure docker login for gcr ..."
          gcloud auth configure-docker gcr.io

  my-profile-4:
    env:
      - name: TEST1
        value: ~/.config
    init-script:
      - run: *commons-gcloud-login
      - run: |
          echo "configure docker login for gcr ..."
          gcloud auth configure-docker gcr.io
```